### PR TITLE
Add demo launcher with RecyclerView navigation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".LifecycleScopeActivity"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/kotlinandroidsample/DemoAdapter.kt
+++ b/app/src/main/java/com/example/kotlinandroidsample/DemoAdapter.kt
@@ -1,0 +1,40 @@
+package com.example.kotlinandroidsample
+
+import android.content.Intent
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+
+class DemoAdapter(
+    private val demoList: List<DemoItem>
+) : RecyclerView.Adapter<DemoAdapter.DemoViewHolder>() {
+
+    inner class DemoViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val tvTitle: TextView = itemView.findViewById(R.id.tv_title)
+        private val tvDescription: TextView = itemView.findViewById(R.id.tv_description)
+
+        fun bind(demoItem: DemoItem) {
+            tvTitle.text = demoItem.title
+            tvDescription.text = demoItem.description
+
+            itemView.setOnClickListener {
+                val intent = Intent(itemView.context, demoItem.targetActivity.java)
+                itemView.context.startActivity(intent)
+            }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DemoViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_demo, parent, false)
+        return DemoViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: DemoViewHolder, position: Int) {
+        holder.bind(demoList[position])
+    }
+
+    override fun getItemCount(): Int = demoList.size
+}

--- a/app/src/main/java/com/example/kotlinandroidsample/DemoItem.kt
+++ b/app/src/main/java/com/example/kotlinandroidsample/DemoItem.kt
@@ -1,0 +1,10 @@
+package com.example.kotlinandroidsample
+
+import android.app.Activity
+import kotlin.reflect.KClass
+
+data class DemoItem(
+    val title: String,
+    val description: String,
+    val targetActivity: KClass<out Activity>
+)

--- a/app/src/main/java/com/example/kotlinandroidsample/LifecycleScopeActivity.kt
+++ b/app/src/main/java/com/example/kotlinandroidsample/LifecycleScopeActivity.kt
@@ -1,0 +1,44 @@
+package com.example.kotlinandroidsample
+
+import android.os.Bundle
+import android.widget.TextView
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class LifecycleScopeActivity : AppCompatActivity() {
+
+    private lateinit var tvStatus: TextView
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContentView(R.layout.activity_lifecycle_scope)
+
+        tvStatus = findViewById(R.id.tv_status)
+
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
+            insets
+        }
+
+        lifecycleScope.launch(Dispatchers.IO) {
+            val result = initialize()
+            withContext(Dispatchers.Main) {
+                tvStatus.text = result
+            }
+        }
+    }
+
+    private suspend fun initialize(): String {
+        delay(3000)
+        return "Finish"
+    }
+}

--- a/app/src/main/java/com/example/kotlinandroidsample/MainActivity.kt
+++ b/app/src/main/java/com/example/kotlinandroidsample/MainActivity.kt
@@ -1,41 +1,43 @@
 package com.example.kotlinandroidsample
 
 import android.os.Bundle
-import android.widget.TextView
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
-import androidx.lifecycle.lifecycleScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import androidx.recyclerview.widget.RecyclerView
 
 class MainActivity : AppCompatActivity() {
 
-    private lateinit var tvStatus: TextView
+    private lateinit var rvDemoList: RecyclerView
+    private lateinit var demoAdapter: DemoAdapter
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContentView(R.layout.activity_main)
-        tvStatus = findViewById(R.id.tv_status)
+
+        rvDemoList = findViewById(R.id.rv_demo_list)
+
         ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
             insets
         }
-        lifecycleScope.launch(Dispatchers.IO) {
-            val result = initialize()
-            withContext(Dispatchers.Main) {
-                tvStatus.text = result
-            }
-        }
+
+        setupDemoList()
     }
 
-    private suspend fun initialize(): String {
-        delay(3000)
-        return "Finish"
+    private fun setupDemoList() {
+        val demoList = listOf(
+            DemoItem(
+                title = getString(R.string.demo_lifecycle_scope_title),
+                description = getString(R.string.demo_lifecycle_scope_description),
+                targetActivity = LifecycleScopeActivity::class
+            )
+        )
+
+        demoAdapter = DemoAdapter(demoList)
+        rvDemoList.adapter = demoAdapter
     }
 }

--- a/app/src/main/res/layout/activity_lifecycle_scope.xml
+++ b/app/src/main/res/layout/activity_lifecycle_scope.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".LifecycleScopeActivity">
+
+    <TextView
+        android:id="@+id/tv_status"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Loading..."
+        android:textSize="18sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,14 +7,13 @@
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
-    <TextView
-        android:id="@+id/tv_status"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Loading..."
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rv_demo_list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:clipToPadding="false"
+        android:padding="8dp"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        tools:listitem="@layout/item_demo" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_demo.xml
+++ b/app/src/main/res/layout/item_demo.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="8dp"
+    app:cardElevation="2dp"
+    app:cardCornerRadius="12dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/tv_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            tools:text="Demo Title"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            android:textColor="?attr/colorOnSurface" />
+
+        <TextView
+            android:id="@+id/tv_description"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            tools:text="Demo Description"
+            android:textSize="14sp"
+            android:textColor="?attr/colorOnSurfaceVariant" />
+
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
     <string name="app_name">Kotlin Android Sample</string>
+    <string name="demo_lifecycle_scope_title">LifecycleScope Demo</string>
+    <string name="demo_lifecycle_scope_description">Demonstrates lifecycle-aware coroutine usage</string>
 </resources>


### PR DESCRIPTION
## Summary
- Refactored MainActivity into a demo launcher with RecyclerView-based navigation
- Moved original lifecycleScope demo into a separate LifecycleScopeActivity
- Added reusable adapter and data model for displaying demo items
- Implemented Material Design card-based UI for demo list items

## Changes
- Created DemoAdapter.kt for RecyclerView adapter implementation
- Created DemoItem.kt data class for demo metadata
- Created LifecycleScopeActivity.kt (moved from MainActivity)
- Refactored MainActivity.kt to display demo list instead of single demo
- Added activity_lifecycle_scope.xml layout for the lifecycle demo
- Updated activity_main.xml to use RecyclerView
- Added item_demo.xml for Material card-based list items
- Updated AndroidManifest.xml to register LifecycleScopeActivity
- Added demo-related string resources in strings.xml

## Test plan
- [x] Build the project successfully
- [x] Run the app and verify demo list displays correctly
- [ ] Click on "LifecycleScope Demo" item and verify navigation works
- [x] Verify lifecycle demo functionality (3-second delay, status update)
- [x] Check Material Design card styling renders properly
- [ ] Verify back navigation from demo activity returns to launcher